### PR TITLE
🐳

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,0 +1,5 @@
+FROM node:alpine
+
+COPY . /nagibabel.js
+RUN cd /nagibabel.js && npm install --ignore-scripts
+ENTRYPOINT ["/nagibabel.js/bin/nagibabel.js", "--path"]

--- a/README.md
+++ b/README.md
@@ -16,3 +16,21 @@ git clone https://github.com/fual/nagibabel.js
 cd nagibabel.js
 node index.js
 ```
+
+### Using Docker
+
+You can also run nagigbabel.js with Docker:
+
+```sh
+docker build -t nagibabel .
+docker run --rm -v /my/awesome/project:/my/awesome/project nagibabel /my/awesome/project
+```
+
+Due to the technical limitations of Docker, only the directory contents are processed, not the directory itself.
+
+You can bypass it by mounting the directory that contains your target folder:
+
+```sh
+docker build -t nagibabel .
+docker run --rm -v /my/awesome/:/my/awesome/ nagibabel /my/awesome/project
+```

--- a/index.js
+++ b/index.js
@@ -1,3 +1,4 @@
+const path = require('path')
 const rimraf = require('rimraf')
 const minimist = require('minimist')
 
@@ -5,7 +6,15 @@ const projectDir = process.cwd()
 const args = minimist(process.argv.slice(2))
 
 const pathToDelete = args.path || projectDir
+const successMsg = 'All bad code is cleared. 😎'
 
-rimraf(pathToDelete, () => {
-  console.log('All bad code is cleared. 😎')
+rimraf(pathToDelete, (er) => {
+  if (er) {
+    // "best-effort" fallback
+    rimraf(path.join(pathToDelete, '*'), () => {
+      console.log(successMsg)
+    })
+    return
+  }
+  console.log(successMsg)
 })


### PR DESCRIPTION
Hey guys!

First of all, kudos for designing and implementing nagibabel.js, it proposes a paradigm that I tried on several of my unfinished pet projects and it works just great! Looking forward to the moment the industry largely adapts the approach.

I thought that it might be great to make nagibabel.js more user-friendly towards those devs, who do not have node installed on their machines. So, I wrote a tiny Dockerfile that allows to run nagibabel.js as a container (containers are still sexy, right?).

Unfortunately, Docker does not allow to process a mounted directory directly, and to deal with this limitation I decided to change the nagibabel.js code a bit by using a "best-effort" scenario in case of a rimraf error.

Tell me what you think about this. If you prefer not to change the logic of the utility, we can fallback to the second method of the container usage (as described in README.md).

Cheers